### PR TITLE
pass options from layer instantiation to load event

### DIFF
--- a/src/KMZLayer.js
+++ b/src/KMZLayer.js
@@ -23,13 +23,13 @@ export const KMZLayer = L.KMZLayer = L.FeatureGroup.extend({
 		this.load(kmzUrl);
 	},
 
-	load: function(kmzUrl) {
+	load: function(kmzUrl, options) {
 		L.KMZLayer._jsPromise = _.lazyLoader(this._requiredJSModules(), L.KMZLayer._jsPromise)
-			.then(() => this._load(kmzUrl));
+			.then(() => this._load(kmzUrl, options));
 	},
 
-	_load: function(url) {
-		return _.loadFile(url).then((data) => this._parse(data, { name: _.getFileName(url), icons: {} }));
+	_load: function(url, options) {
+		return _.loadFile(url).then((data) => this._parse(data, { name: _.getFileName(url), icons: {}, options: options }));
 	},
 
 	_parse: function(data, props) {


### PR DESCRIPTION
I needed to include some metadata around the layer when adding the control, but this wasn't available on the "load" event.

This lets you load the layer with
```js
kmz.load(url, options)
```

and then add the control with e.g.:

```js
kmz.on('load', function(e) {
  control.addOverlay(e.layer, `<a href="${e.props.options.url}" target="_blank">${e.props.options.name}</a>`);
  e.layer.addTo(map);
});
```