### PR TITLE
Add `emptyIcon` as fallback for markers without iconUrl

### DIFF
--- a/src/KMZLayer.js
+++ b/src/KMZLayer.js
@@ -62,20 +62,13 @@ export const KMZLayer = L.KMZLayer = L.FeatureGroup.extend({
 
 	_geometryToLayer: function(data, xml) {
 		var preferCanvas = this._map ? this._map.options.preferCanvas : this.options.preferCanvas;
+		var emptyIcon    = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E";
 		// parse GeoJSON
 		var layer = L.geoJson(data, {
 			pointToLayer: (feature, latlng) => {
-				
-				const iconUrl = data.properties.icons[feature.properties.icon] || feature.properties.icon;
-
-				if (!iconUrl) {
-				    console.debug('Marker icon URL is missing', feature);
-				    return;
-				}
-				
 				if (preferCanvas) {
 					return L.kmzMarker(latlng, {
-						iconUrl: iconUrl,
+						iconUrl: data.properties.icons[feature.properties.icon] || feature.properties.icon || emptyIcon,
 						iconSize: [28, 28],
 						iconAnchor: [14, 14],
 						interactive: this.options.interactive,
@@ -84,7 +77,7 @@ export const KMZLayer = L.KMZLayer = L.FeatureGroup.extend({
 				// TODO: handle L.svg renderer within the L.KMZMarker class?
 				return L.marker(latlng, {
 					icon: L.icon({
-						iconUrl: iconUrl,
+						iconUrl: data.properties.icons[feature.properties.icon] || feature.properties.icon || emptyIcon,
 						iconSize: [28, 28],
 						iconAnchor: [14, 14],
 					}),

--- a/src/KMZLayer.js
+++ b/src/KMZLayer.js
@@ -65,9 +65,17 @@ export const KMZLayer = L.KMZLayer = L.FeatureGroup.extend({
 		// parse GeoJSON
 		var layer = L.geoJson(data, {
 			pointToLayer: (feature, latlng) => {
+				
+				const iconUrl = data.properties.icons[feature.properties.icon] || feature.properties.icon;
+
+				if (!iconUrl) {
+				    console.debug('Marker icon URL is missing', feature);
+				    return;
+				}
+				
 				if (preferCanvas) {
 					return L.kmzMarker(latlng, {
-						iconUrl: data.properties.icons[feature.properties.icon] || feature.properties.icon,
+						iconUrl: iconUrl,
 						iconSize: [28, 28],
 						iconAnchor: [14, 14],
 						interactive: this.options.interactive,
@@ -76,7 +84,7 @@ export const KMZLayer = L.KMZLayer = L.FeatureGroup.extend({
 				// TODO: handle L.svg renderer within the L.KMZMarker class?
 				return L.marker(latlng, {
 					icon: L.icon({
-						iconUrl: data.properties.icons[feature.properties.icon] || feature.properties.icon,
+						iconUrl: iconUrl,
 						iconSize: [28, 28],
 						iconAnchor: [14, 14],
 					}),


### PR DESCRIPTION
A KML file I was working with included no URL of the marker:

```xml
<Folder>
	<name>Text [DCC]</name>
	<Placemark>
		<name>3</name>
		<Style>
			<IconStyle>
				<Icon>
				</Icon>
			</IconStyle>
		</Style>
		<Point>
			<coordinates>136.864622810419,-30.447964988285,0</coordinates>
		</Point>
	</Placemark>
</Folder>
```

Leaflet doesn't allow this, and throws an error (see https://github.com/Leaflet/Leaflet/issues/4334). This change doesn't fix the problem of a missing icon, but at least allows rendering the other features correctly.